### PR TITLE
fix error with comparing ALL to all

### DIFF
--- a/src/com/sucy/skill/dynamic/mechanic/CleanseMechanic.java
+++ b/src/com/sucy/skill/dynamic/mechanic/CleanseMechanic.java
@@ -62,7 +62,7 @@ public class CleanseMechanic extends EffectComponent
     {
         boolean worked = false;
         String status = settings.getString(STATUS, "None").toLowerCase();
-        String potion = settings.getString(POTION).toUpperCase().replace(' ', '_');
+        String potion = settings.getString(POTION).toLowerCase().replace(' ', '_');
         PotionEffectType type = null;
         try
         {


### PR DESCRIPTION
Right now, we toUpperCase the potion input only to try comparing it to 'all', which always fails resulting in no cleanse happening if potion: 'all'