### PR TITLE
Fix modified xp values from event being ignored

### DIFF
--- a/src/com/sucy/skill/api/player/PlayerClass.java
+++ b/src/com/sucy/skill/api/player/PlayerClass.java
@@ -323,6 +323,7 @@ public final class PlayerClass
         // Add experience if not cancelled
         if (!event.isCancelled() && event.getExp() > 0)
         {
+            amount = event.getExp();
             if (SkillAPI.getSettings().isShowExpMessages() && player.getPlayer() != null)
             {
                 TitleManager.show(


### PR DESCRIPTION
When the xp of the PlayerExperienceGainEvent has been modified it was ignored and the original value was added to the players class. Only affects the free version.
This should fix it.